### PR TITLE
Handle panics so that it works the way that DeepEqual works natively

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -103,7 +103,15 @@ func GetInternalProtobufFields() []string {
 // proto bindings via backend/tools/generators/service/service.part.generated.go.tmpl
 // and it is not yet fully compatible with the new protobuf library. In particular, it does
 // not implement ProtoReflect.
-func ProtoEqual(a, b interface{}) bool {
+func ProtoEqual(a, b interface{}) (returnValue bool) {
+	defer func() {
+		if v := recover(); v != nil {
+			// If this panics, return reflect.DeepEqual. This will happen
+			// if the message contains private variables that are not the proto variables.
+			returnValue = reflect.DeepEqual(a, b)
+		}
+	}()
+
 	return cmp.Equal(a, b, IgnoreInternalProtoFieldsOption())
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -111,6 +111,11 @@ type TestProto2 struct {
 	Test *TestProto
 }
 
+type PrivateFields struct {
+	Field1 string
+	field2 string
+}
+
 func TestObjectsAreEqual(t *testing.T) {
 	testProtoA := &TestProto{Field1: "A", state: "A", sizeCache: "A", unknownFields: "A"}
 	testProtoB := &TestProto{Field1: "A", state: "B", sizeCache: "B", unknownFields: "B"}
@@ -118,6 +123,9 @@ func TestObjectsAreEqual(t *testing.T) {
 	testProto2A := &TestProto2{testProtoA}
 	testProto2B := &TestProto2{testProtoB}
 	testProto2C := &TestProto2{testProtoC}
+	testRandomA1 := &PrivateFields{"A", "A"}
+	testRandomA2 := &PrivateFields{"A", "A"}
+	testRandomB := &PrivateFields{"A", "B"}
 
 	cases := []struct {
 		expected interface{}
@@ -133,6 +141,7 @@ func TestObjectsAreEqual(t *testing.T) {
 		{testProtoA, testProtoB, true},
 		{[]*TestProto{testProtoA}, []*TestProto{testProtoB}, true},
 		{testProto2A, testProto2B, true},
+		{testRandomA1, testRandomA2, true},
 
 		// cases that are expected not to be equal
 		{map[int]int{5: 10}, map[int]int{10: 20}, false},
@@ -146,6 +155,7 @@ func TestObjectsAreEqual(t *testing.T) {
 		{testProtoA, testProtoC, false},
 		{[]*TestProto{testProtoA}, []*TestProto{testProtoC}, false},
 		{testProto2A, testProto2C, false},
+		{testRandomA1, testRandomB, false},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Needed because the behavior isn't exactly the same-- go-cmp dies when it comes across unexported fields while reflect.DeepEqual does not.